### PR TITLE
Fix deletePost test with a handler

### DIFF
--- a/src/post/client/__tests__/deletePost.test.ts
+++ b/src/post/client/__tests__/deletePost.test.ts
@@ -1,6 +1,5 @@
 import { huevosRotosBruc159PostDto } from "../../dto/fixturesDto";
 import { mapPostDtoToPost } from "../../dto/mappers";
-import { huevosRotosBruc159PostData } from "../../fixtures";
 import PostClient from "../PostClient";
 
 describe("Given the deletePost method to PostClient", () => {
@@ -8,7 +7,9 @@ describe("Given the deletePost method to PostClient", () => {
     test("Then it should return Huevos rotos de Bruc, 159 post", async () => {
       const postClient = new PostClient();
 
-      const deletedPost = await postClient.addPost(huevosRotosBruc159PostData);
+      const deletedPost = await postClient.deletePost(
+        huevosRotosBruc159PostDto._id,
+      );
 
       const postHuevos = mapPostDtoToPost(huevosRotosBruc159PostDto);
 

--- a/src/post/mocks/handlers.ts
+++ b/src/post/mocks/handlers.ts
@@ -19,11 +19,15 @@ export const handlers = [
     });
   }),
 
+  http.get(`${apiUrl}/posts/159678901234567890123456`, () => {
+    return HttpResponse.json<PostDto>(huevosRotosBruc159PostDto);
+  }),
+
   http.post(`${apiUrl}/posts`, () => {
     return HttpResponse.json<PostDto>(huevosRotosBruc159PostDto);
   }),
 
-  http.get(`${apiUrl}/posts/159678901234567890123456`, () => {
+  http.delete(`${apiUrl}/posts/159678901234567890123456`, () => {
     return HttpResponse.json<PostDto>(huevosRotosBruc159PostDto);
   }),
 ];


### PR DESCRIPTION
Fixed the deletePost test for PostsClient with a handler for DELETE /post:id