### PR TITLE
Fix PostsPage test to check post title before delete

### DIFF
--- a/src/post/pages/PostsPage/PostsPage.test.tsx
+++ b/src/post/pages/PostsPage/PostsPage.test.tsx
@@ -50,15 +50,21 @@ describe("Given the PostsPage component", () => {
         { wrapper: MemoryRouter },
       );
 
+      const postTitle = await screen.findByRole("heading", {
+        name: expectedTitleRegex,
+      });
+
+      expect(postTitle).toBeVisible();
+
       const deleteButtons = await screen.findAllByLabelText(/eliminar post/i);
 
       await user.click(deleteButtons[0]);
 
-      const postTitle = await screen.queryByRole("heading", {
+      const deletedPostTitle = await screen.queryByRole("heading", {
         name: expectedTitleRegex,
       });
 
-      expect(postTitle).toBeNull();
+      expect(deletedPostTitle).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Added a check in PostsPage test for post title before user clicks the delete button of the post card